### PR TITLE
Make the loose file romfs loading work with glibc+gcc

### DIFF
--- a/src/core/file_sys/romfs_l3data.cpp
+++ b/src/core/file_sys/romfs_l3data.cpp
@@ -6,14 +6,17 @@
 #include "common/file_util.h"
 #include "romfs_l3data.h"
 
+#include <locale>
+#include <cstring>
+
 namespace FileSys {
 
 s64 Align(s64 a_nData, s64 a_nAlignment) {
     return (a_nData + a_nAlignment - 1) / a_nAlignment * a_nAlignment;
 }
 
-u16str ToU16(const std::string& s) {
-    std::wstring_convert<std::codecvt_utf8_utf16<std::uint16_t>, std::uint16_t> conv;
+std::u16string ToU16(const std::string& s) {
+    std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conv;
     return conv.from_bytes(s);
 }
 
@@ -370,7 +373,7 @@ void RomFSL3::buildHeaderData() {
               cFileSizeAlignment));
 }
 
-u32 RomFSL3::hash(s32 parentOffset, u16str& entryName) {
+u32 RomFSL3::hash(s32 parentOffset, std::u16string& entryName) {
     u32 uHash = parentOffset ^ 123456789;
     for (int i = 0; i < static_cast<int>(entryName.size()); i++) {
         uHash = ((uHash >> 5) | (uHash << 27)) ^ entryName[i];

--- a/src/core/file_sys/romfs_l3data.h
+++ b/src/core/file_sys/romfs_l3data.h
@@ -22,8 +22,6 @@
 
 namespace FileSys {
 
-typedef std::basic_string<std::uint16_t> u16str;
-
 #include SDW_MSC_PUSH_PACKED
 struct l3HeaderSection {
     u32 Offset;
@@ -79,7 +77,7 @@ class RomFSL3 {
     struct l3Entry // File/Dir entry created when packing
     {
         std::string Path;    //  absolote local file/dir path (on your computer)
-        u16str EntryName;    //  name of the file/dir
+        std::u16string EntryName;    //  name of the file/dir
         int EntryNameSize;   //  length of above name
         s32 EntryOffset;     //
         s32 BucketIndex;     //
@@ -128,7 +126,7 @@ private:
 
     void buildHeaderData();
 
-    u32 hash(s32 a_nParentOffset, u16str& a_sEntryName);
+    u32 hash(s32 a_nParentOffset, std::u16string& a_sEntryName);
 
     std::string romFsDirName;
 


### PR DESCRIPTION
Make it work on my computer. Just add missing header, and replace the custom u16str to the standard u16string (basic string aren't intended to work with u16).